### PR TITLE
Fixed test cases - removed dicer and other methods that use permutati…

### DIFF
--- a/tests/testthat/test_evaluation.R
+++ b/tests/testthat/test_evaluation.R
@@ -5,17 +5,25 @@ library(stringr)
 context('Simulation accessors ')
 
 data("sim102")
-#pick a representative set
-infmethods = c('zscore', 'diffcoex', 'dicer', 'ebcoexpress')
-if (!require('EBcoexpress')) {
-  infmethods = setdiff(infmethods, 'ebcoexpress')
-}
-if (!require('COSINE')) {
-  infmethods = setdiff(infmethods, 'ecf')
+
+#pick a representative set - exclude any method that uses perm test during check
+getInfMethods <- function() {
+  infmethods = c('zscore', 'diffcoex', 'ebcoexpress', 'ecf', 'ggm-based')
+  if (!require('EBcoexpress')) {
+    infmethods = setdiff(infmethods, 'ebcoexpress')
+  }
+  if (!require('COSINE')) {
+    infmethods = setdiff(infmethods, 'ecf')
+  }
+  if (!require('GeneNet')) {
+    infmethods = setdiff(infmethods, 'ggm-based')
+  }
+
+  return(infmethods)
 }
 
 test_that('Result of pipeline ', {
-  for(m in infmethods) {
+  for(m in getInfMethods()) {
     res = dcPipeline(sim102, dc.func = m)
     expect_equal(length(res), 2, info = m)
     expect_equal(as.numeric(lapply(res, function(x) length(V(x)))), rep(nrow(sim102$data), 2), info = m)
@@ -24,7 +32,7 @@ test_that('Result of pipeline ', {
 })
 
 test_that('Evaluation of pipeline results ', {
-  for(m in infmethods) {
+  for(m in getInfMethods()) {
     nets = dcPipeline(sim102, dc.func = m)
     res = dcEvaluate(sim102, dclist = nets, perf.method = 'f.measure', combine = TRUE)
     expect_equal(length(res), 1, info = m)

--- a/tests/testthat/test_inference_methods.R
+++ b/tests/testthat/test_inference_methods.R
@@ -13,19 +13,37 @@ colnames(x) = 1:ncol(x)
 rownames(x) = 1:nrow(x)
 cond <- rep(1:2, each = 30)
 
+getInfMethods <- function() {
+  infmethods = dcMethods()
+  if (!require('EBcoexpress')) {
+    infmethods = setdiff(infmethods, 'ebcoexpress')
+  }
+  if (!require('COSINE')) {
+    infmethods = setdiff(infmethods, 'ecf')
+  }
+  if (!require('GeneNet')) {
+    infmethods = setdiff(infmethods, 'ggm-based')
+  }
+
+  return(infmethods)
+}
+
 test_that('Inference method calls work', {
   expect_is(dcScore(x, cond), 'matrix')
   expect_is(dcScore(x, cond, dc.method = 'zscore'), 'matrix')
-  for (m in setdiff(dcMethods(), 'ebcoexpress')) {
+  for (m in getInfMethods()) {
     expect_is(dcScore(x, cond, !!m), 'matrix')
   }
 
-  try(detach('package:EBcoexpress', unload = T), silent = TRUE)
-  try(detach('package:mclust', unload = T), silent = TRUE)
-  try(detach('package:minqa', unload = T), silent = TRUE)
-  expect_error(dcScore(x, cond, 'ebcoexpress'), 'loading the EBcoexpress library')
-  library(EBcoexpress)
-  expect_is(dcScore(x, cond, 'ebcoexpress'), 'matrix')
+  if (!'ebcoexpress' %in% getInfMethods()) {
+    expect_error(dcScore(x, cond, 'ebcoexpress'), 'needed for this function to work')
+  }
+  if (!'ecf' %in% getInfMethods()) {
+    expect_error(dcScore(x, cond, 'ecf'), 'needed for this function to work')
+  }
+  if (!'ggm-based' %in% getInfMethods()) {
+    expect_error(dcScore(x, cond, 'ggm-based'), 'needed for this function to work')
+  }
 
   expect_error(dcScore(x, cond, 'fakemethod'), 'not TRUE')
   expect_error(dcScore(x, cond, cor.method = 'kendall'), 'not TRUE')
@@ -34,25 +52,25 @@ test_that('Inference method calls work', {
 })
 
 test_that('Correct dimensions of results', {
-  for (m in dcMethods()) {
+  for (m in getInfMethods()) {
     expect_equal(dim(dcScore(x, cond, !!m)), c(4, 4))
   }
 })
 
 test_that('Attributes attached to results', {
-  for (m in dcMethods()) {
+  for (m in getInfMethods()) {
     expect_equal(attr(dcScore(x, cond, !!m), 'dc.method'), m)
   }
 })
 
 test_that('Diagonals are NAs', {
-  for (m in dcMethods()) {
+  for (m in getInfMethods()) {
     expect_equal(sum(is.na(diag(dcScore(x, cond, !!m)))), nrow(x))
   }
 })
 
 test_that('Row and column names are the same', {
-  for (m in dcMethods()) {
+  for (m in getInfMethods()) {
     expect_equal(rownames(dcScore(x, cond, !!m)), colnames(dcScore(x, cond, !!m)))
   }
 })

--- a/tests/testthat/test_multtest_adjust.R
+++ b/tests/testthat/test_multtest_adjust.R
@@ -12,33 +12,37 @@ colnames(x) = 1:ncol(x)
 rownames(x) = 1:nrow(x)
 cond = rep(1:2, each = 30)
 
-#run all methods and store results
-infmethods = dcMethods()
-if (!require('EBcoexpress')) {
-  infmethods = setdiff(infmethods, 'ebcoexpress')
-}
-if (!require('COSINE')) {
-  infmethods = setdiff(infmethods, 'ecf')
+#pick a representative set - exclude any method that uses perm test during check
+getInfMethods <- function() {
+  infmethods = c('zscore', 'diffcoex', 'ebcoexpress', 'ecf', 'ggm-based')
+  if (!require('EBcoexpress')) {
+    infmethods = setdiff(infmethods, 'ebcoexpress')
+  }
+  if (!require('COSINE')) {
+    infmethods = setdiff(infmethods, 'ecf')
+  }
+  if (!require('GeneNet')) {
+    infmethods = setdiff(infmethods, 'ggm-based')
+  }
+
+  return(infmethods)
 }
 
-scorelist = lapply(infmethods, function (m) dcScore(x, cond, m))
-names(scorelist) = infmethods
+scorelist = lapply(getInfMethods(), function (m) dcScore(x, cond, m))
+names(scorelist) = getInfMethods()
 
 #generate test matrices
 testmats <- lapply(scorelist, function(s) dcTest(s, x, cond))
 
 test_that('Testing calls work', {
-  for (m in setdiff(infmethods, c('ebcoexpress', 'diffcoex'))) {
+  for (m in getInfMethods()) {
     expect_is(dcAdjust(testmats[[!!m]]), 'matrix')
   }
-
-  if ('ebcoexpress' %in% infmethods)
-    expect_is(dcAdjust(testmats[['ebcoexpress']]), 'matrix')
-  expect_is(dcAdjust(testmats[['diffcoex']]), 'matrix')
 })
 
 test_that('Testing attribute changes', {
-  for (m in setdiff(infmethods, c('ebcoexpress', 'diffcoex'))) {
+  for (m in setdiff(getInfMethods(), 'diffcoex')) {
     expect_output(str(attr(dcAdjust(testmats[[!!m]]), 'dc.test')), regexp = 'adj')
   }
+  expect_output(str(attr(dcAdjust(testmats[['diffcoex']]), 'dc.test')), regexp = 'none')
 })

--- a/tests/testthat/test_statistical_tests.R
+++ b/tests/testthat/test_statistical_tests.R
@@ -12,20 +12,27 @@ colnames(x) = 1:ncol(x)
 rownames(x) = 1:nrow(x)
 cond <- rep(1:2, each = 30)
 
-#run all methods and store results
-infmethods = dcMethods()
-if (!require('EBcoexpress')) {
-  infmethods = setdiff(infmethods, 'ebcoexpress')
-}
-if (!require('COSINE')) {
-  infmethods = setdiff(infmethods, 'ecf')
+#pick a representative set - exclude any method that uses perm test during check
+getInfMethods <- function() {
+  infmethods = c('zscore', 'diffcoex', 'ebcoexpress', 'ecf', 'ggm-based')
+  if (!require('EBcoexpress')) {
+    infmethods = setdiff(infmethods, 'ebcoexpress')
+  }
+  if (!require('COSINE')) {
+    infmethods = setdiff(infmethods, 'ecf')
+  }
+  if (!require('GeneNet')) {
+    infmethods = setdiff(infmethods, 'ggm-based')
+  }
+
+  return(infmethods)
 }
 
-scorelist <- lapply(infmethods, function (m) dcScore(x, cond, m))
-names(scorelist) <- infmethods
+scorelist <- lapply(getInfMethods(), function (m) dcScore(x, cond, m))
+names(scorelist) <- getInfMethods()
 
 test_that('Testing calls work', {
-  for (m in infmethods) {
+  for (m in getInfMethods()) {
     expect_is(dcTest(scorelist[[!!m]], x, cond), 'matrix')
   }
 })
@@ -34,25 +41,25 @@ test_that('Testing calls work', {
 testmats <- lapply(scorelist, function(s) dcTest(s, x, cond))
 
 test_that('Correct dimensions of results', {
-  for (m in infmethods) {
+  for (m in getInfMethods()) {
     expect_equal(dim(testmats[[!!m]]), c(4, 4))
   }
 })
 
 test_that('Attributes attached to results', {
-  for (m in infmethods) {
+  for (m in getInfMethods()) {
     expect_output(str(attr(testmats[[!!m]], 'dc.test')), regexp = '.')
   }
 })
 
 test_that('Diagonals are NAs', {
-  for (m in infmethods) {
+  for (m in getInfMethods()) {
     expect_equal(sum(is.na(diag(testmats[[!!m]]))), nrow(x))
   }
 })
 
 test_that('Values are in range for statistical tests', {
-  for (m in setdiff(infmethods, 'diffcoex')) {
+  for (m in setdiff(getInfMethods(), 'diffcoex')) {
     expect_gte(min(testmats[[!!m]], na.rm = TRUE), 0)
     expect_lte(max(testmats[[!!m]], na.rm = TRUE), 1)
   }


### PR DESCRIPTION
…on tests from unit tests. They use foreach which is creating issues with the R CMD check.